### PR TITLE
Rremove logging, add support for ABBREVIATIONCase

### DIFF
--- a/src/justin.gleam
+++ b/src/justin.gleam
@@ -1,6 +1,6 @@
-import gleam/string
 import gleam/io
 import gleam/list
+import gleam/string
 
 /// Convert a string to a `snake_case`.
 ///
@@ -114,13 +114,33 @@ fn split(
     | [" ", ..in] -> split(in, False, "", add(words, word))
 
     [g, ..in] -> {
-      io.println(string.inspect(#(g, is_upper(g))))
       case is_upper(g) {
         // Lowercase, not a new word
         False -> split(in, False, word <> g, words)
-
-        // Uppercase and inside an uppercase word, not a new word
-        True if up -> split(in, up, word <> g, words)
+        // Uppercase and inside an uppercase word
+        True if up -> {
+          case in {
+            []
+            | ["\n", ..]
+            | ["\t", ..]
+            | ["!", ..]
+            | ["?", ..]
+            | ["#", ..]
+            | [".", ..]
+            | ["-", ..]
+            | ["_", ..]
+            | [" ", ..] -> split(in, up, word <> g, words)
+            [nxt, ..] -> {
+              case is_upper(nxt) {
+                True -> split(in, up, word <> g, words)
+                // It's a new word if the next letter is lowercase
+                False -> {
+                  split(in, False, g, add(words, word))
+                }
+              }
+            }
+          }
+        }
 
         // Uppercase otherwise, a new word
         True -> split(in, True, g, add(words, word))

--- a/test/justin_test.gleam
+++ b/test/justin_test.gleam
@@ -1,5 +1,5 @@
-import gleeunit
 import gleam/list
+import gleeunit
 import justin
 
 pub fn main() {
@@ -10,6 +10,7 @@ const snake_cases = [
   #("", ""),
   #("snake case", "snake_case"),
   #("snakeCase", "snake_case"),
+  #("SNAKECase", "snake_case"),
   #("Snake-Case", "snake_case"),
   #("Snake_Case", "snake_case"),
   #("SnakeCase", "snake_case"),
@@ -28,6 +29,7 @@ const camel_cases = [
   #("snake case", "snakeCase"),
   #("snakeCase", "snakeCase"),
   #("Snake-Case", "snakeCase"),
+  #("SNAKECase", "snakeCase"),
   #("Snake_Case", "snakeCase"),
   #("SnakeCase", "snakeCase"),
   #("Snake.Case", "snakeCase"),
@@ -44,6 +46,7 @@ const pascal_cases = [
   #("", ""),
   #("snake case", "SnakeCase"),
   #("snakeCase", "SnakeCase"),
+  #("SNAKECase", "SnakeCase"),
   #("Snake-Case", "SnakeCase"),
   #("Snake_Case", "SnakeCase"),
   #("SnakeCase", "SnakeCase"),
@@ -61,6 +64,7 @@ const kebab_cases = [
   #("", ""),
   #("snake case", "snake-case"),
   #("snakeCase", "snake-case"),
+  #("SNAKECase", "snake-case"),
   #("Snake-Case", "snake-case"),
   #("Snake_Case", "snake-case"),
   #("SnakeCase", "snake-case"),
@@ -78,6 +82,7 @@ const sentence_cases = [
   #("", ""),
   #("snake case", "Snake case"),
   #("snakeCase", "Snake case"),
+  #("SNAKECase", "Snake case"),
   #("Snake-Case", "Snake case"),
   #("Snake_Case", "Snake case"),
   #("SnakeCase", "Snake case"),


### PR DESCRIPTION
Support this use case:

```gleam
  justin.snake_case("DOMDebugger")
  |> should.equal("dom_debugger")
  justin.snake_case("CSSLayerData")
  |> should.equal("css_layer_data")
```
And remove a line logging every character of the passed string.

See: #1 